### PR TITLE
Gather bookmarks

### DIFF
--- a/ebuku.el
+++ b/ebuku.el
@@ -432,7 +432,6 @@ The bookmarks is fetched from buku with the following arguments:
           (push data results)))
       results)))
 
-
 (defun ebuku--search-helper (type prompt &optional term exclude)
   "Internal function to call `buku' with appropriate search arguments.
 
@@ -598,7 +597,6 @@ Argument EXCLUDE is a string: keywords to exclude from search results."
 ;;
 ;; User-facing variables.
 ;;
-
 
 (defvar ebuku-bookmarks '()
   "Cache of bookmarks in the buku database.


### PR DESCRIPTION
`ebuku-gather-bookmarks` is now a function (non-interactive). Its purpose is to
search buku and return Emacs suitable data from it. This data could later be
used/added in other functions/commands (like `ebuku--search-helper`). It is not
a "private" function since its pretty modular and could be used in other
packages.

`ebuku-bookmarks` is now updated by the `ebuku-update-cache` command instead.
This command takes the same arguments as `ebuku-gather-bookmarks`, but by
default will take its arguments from `ebuku-cache-default-args`. The default is
to get data from all buku bookmarks.

Unfortunately the README and top of file comments haven't been updated.