### PR TITLE
Replace 'map-put' with '(setf (map-elt ...) ...)'.

### DIFF
--- a/ebuku.el
+++ b/ebuku.el
@@ -167,6 +167,7 @@
 ;;
 
 (require 'browse-url)
+(require 'map)
 
 (defgroup ebuku nil
   "Emacs interface to the buku bookmark manager."
@@ -400,11 +401,11 @@ Using `sqlite' rather than `buku' can be several times faster, but the
                                           "$")
                                   nil t)
           (let* ((bookmark))
-            (map-put bookmark 'index (match-string 1))
-            (map-put bookmark 'url (match-string 2))
-            (map-put bookmark 'title (match-string 3))
-            (map-put bookmark 'tags (split-string (match-string 4) "," t))
-            (map-put bookmark 'comment (match-string 5))
+            (setf (map-elt bookmark 'index) (match-string 1))
+            (setf (map-elt bookmark 'url) (match-string 2))
+            (setf (map-elt bookmark 'title) (match-string 3))
+            (setf (map-elt bookmark 'tags) (split-string (match-string 4) "," t))
+            (setf (map-elt bookmark 'comment) (match-string 5))
             (setq ebuku-bookmarks (cons bookmark ebuku-bookmarks))))))))
 
 (defun ebuku--collect-tags-via-sqlite ()
@@ -1011,22 +1012,22 @@ The bookmarks are fetched from buku with the following arguments:
           (if (or (string= "--print" type)
                   (string= "-p" type))
               (progn
-                (map-put data 'index (match-string 1))
-                (map-put data 'title (match-string 2)))
-            (map-put data 'title (match-string 2))
-            (map-put data 'index (match-string 3)))
+                (setf (map-elt data 'index) (match-string 1))
+                (setf (map-elt data 'title) (match-string 2)))
+            (setf (map-elt data 'title) (match-string 2))
+            (setf (map-elt data 'index) (match-string 3)))
           (re-search-forward "^\\s-+> \\([^\n]+\\)") ; URL
-          (map-put data 'url (match-string 1))
+          (setf (map-elt data 'url) (match-string 1))
           (forward-line)
           (when (looking-at "^\\s-+[+] \\(.+\\)$")
-            (map-put data 'comment (match-string 1))
+            (setf (map-elt data 'comment) (match-string 1))
             (forward-line))
           (when (looking-at "^\\s-+[#] \\(.+\\)$")
-            (map-put data 'tags (or (split-string
-                                     (or (match-string 1)
-                                         "")
-                                     "," t)
-                                    '())))
+            (setf (map-elt data 'tags) (or (split-string
+                                            (or (match-string 1)
+                                                "")
+                                            "," t)
+                                           '())))
           (push data results)))
       results)))
 


### PR DESCRIPTION
This eliminates the following warning: ‘map-put’ is an obsolete macro (as of 27.1); use ‘map-put!’ or ‘(setf (map-elt ...) ...)’ instead.