### PR TITLE
Fix: don't modify kill-ring when opening ebuku buffer

### DIFF
--- a/ebuku.el
+++ b/ebuku.el
@@ -655,7 +655,7 @@ Argument EXCLUDE is a string: keywords to exclude from search results."
         (let ((inhibit-read-only t))
           (ebuku--goto-line ebuku--results-start)
           (beginning-of-line)
-          (kill-region (point) (point-max))
+          (delete-region (point) (point-max))
           (cond
            ((string= "0" count)
             (insert (concat "  No results found for '" search "'.\n\n")))


### PR DESCRIPTION
I noticed that whenever I copy an URL to my clipboard and then open Ebuku for the first time with `ebuku` and call `ebuku-add-bookmark`, my clipboard is empty and I need to copy the URL again.
The simple fix is to use `delete-region` instead of `kill-region`, which I think is better suited in this case anyway.

This patch illustrates the current behavior when running `ebuku` with something in the clipboard:
```diff
diff --git a/ebuku.el b/ebuku.el
index 2394e93..93be6f3 100644
--- a/ebuku.el
+++ b/ebuku.el
@@ -655,7 +655,9 @@ Argument EXCLUDE is a string: keywords to exclude from search results."
         (let ((inhibit-read-only t))
           (ebuku--goto-line ebuku--results-start)
           (beginning-of-line)
+          (message "Before: %s"(current-kill 0 nil))
           (kill-region (point) (point-max))
+          (message "After: %s"(current-kill 0 nil))
           (cond
            ((string= "0" count)
             (insert (concat "  No results found for '" search "'.\n\n")))
```

```
*Messages* 
Before: https://github.com/flexibeast/ebuku
After: 
```
