### PR TITLE
List bookmark columns explicitly when updating cache

### DIFF
--- a/ebuku.el
+++ b/ebuku.el
@@ -383,7 +383,7 @@ Using `sqlite' rather than `buku' can be several times faster, but the
                       nil t nil
                       "-separator" "\037"
                       ebuku-database-path
-                      "select * from bookmarks;")
+                      "select id, url, metadata, tags, desc from bookmarks;")
 
         ;; Refresh cache.
         (goto-char (point-min))


### PR DESCRIPTION
Buku's table has been extended to add a "flags" column, which breaks the regexp used to extract the fields from the query. Explicitly listing the columns requested fixes the breakage now and for any future changes.